### PR TITLE
Use local files to install container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install --yes \
  python-dev
 
  WORKDIR /opt
- RUN git clone https://github.com/NAL-i5K/remap-gff3.git
+ RUN mkdir remap-gff3
+ ADD . /opt/remap-gff3/
  WORKDIR /opt/remap-gff3
- RUN pip install \
-  .
+ RUN pip install .


### PR DESCRIPTION
This can fix the installation error I met in #2. It's because the security issue mentioned in Chaosthebot/Chaos#491. I also used the local files to install container. Another thing is that I met following error messages during the installation:
``` shell
 Running setup.py install for remap-gff3
    /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'project_urls'
      warnings.warn(msg)

    changing mode of /usr/local/bin/remap-gff3.py to 755
    changing mode of /usr/local/bin/get_remove_feature.py to 755
    changing mode of /usr/local/bin/gff_to_chain.py to 755
    changing mode of /usr/local/bin/re_construct_gff3_features.py to 755
  Running setup.py install for bx-python
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip_build_root/bx-python/setup.py", line 266, in <module>
        main()
      File "/tmp/pip_build_root/bx-python/setup.py", line 73, in main
        raise Exception( "numpy must be installed to build" )
    Exception: numpy must be installed to build
    Complete output from command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/bx-python/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-tkiw4w-record/install-record.txt --single-version-externally-managed --compile:
    Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "/tmp/pip_build_root/bx-python/setup.py", line 266, in <module>

    main()

  File "/tmp/pip_build_root/bx-python/setup.py", line 73, in main

    raise Exception( "numpy must be installed to build" )

Exception: numpy must be installed to build

----------------------------------------
Cleaning up...
Command /usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip_build_root/bx-python/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-tkiw4w-record/install-record.txt --single-version-externally-managed --compile failed with error code 1 in /tmp/pip_build_root/bx-python
Storing debug log for failure in /root/.pip/pip.log
The command '/bin/sh -c pip install --upgrade pip && pip install .' returned a non-zero code: 1
```

It seems to me that we still need to include numpy as dependencies.